### PR TITLE
added a bottom-margin of 1.5rem to delete-all-tasks button

### DIFF
--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ form button:hover
   background-color: red;
   color: white;
   width: 200px;
-  margin: auto;
+  margin: auto auto 1.5rem;
 }
 .delete-all:hover {
   background-color: rgb(207, 2, 2);


### PR DESCRIPTION
### Fixes Issue #60 
I have added a **bottom-margin** of 1.5rem to the ```Delete all tasks``` button.  
Now, It will have some amount of margin from the footer section irrespective of the number of tasks added to the **To-do-list**. 
 
## Preview: 
![updatetodo](https://user-images.githubusercontent.com/70108561/136241567-cd97c4d0-2fcc-485c-88c8-a2082978b692.png)
