### PR TITLE
added hover/focus states to socials

### DIFF
--- a/style.css
+++ b/style.css
@@ -245,6 +245,13 @@ select {
   font-family: "Lobster", cursive;
 }
 
+.social-icon:hover,
+.social-icon:focus {
+  border: none;
+  filter: drop-shadow(5px 5px 5px rgb(54, 141, 207));
+}
+
+
 @media only screen and (max-width: 440px) {
   .abc {
     flex-direction: column;


### PR DESCRIPTION
Added subtle drop-shadow to socials when in focus or hovering.  Made the shadow's a slightly darker blue.  See the attached gif.

![socials-hover-focus](https://user-images.githubusercontent.com/70668540/193420201-c80e06e1-9906-40b9-b98d-9b0c4e46672e.gif)
