### PR TITLE
Added info button for refresh page #184

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -55,6 +55,8 @@ function getItemFromLocalStorage() {
 function addTodo(e) {
   //Prevent natural behavior
   e.preventDefault();
+  const createTime = getTime();
+  const infoText = `The todo item was created at ${createTime}, ${day}`;
   const currentValue = htmlEncode(todoInput.value)?.trim() || ""
   if (!currentValue) {
     //alert("Fill the box");
@@ -80,10 +82,10 @@ function addTodo(e) {
     id: Math.round(Math.random() * 100), //id for selection
     task: currentValue,
     status: "incomplete",
+    infoText: infoText,
   };
   todoDiv.setAttribute("key", newTodoItem.id);
 
-  const createTime = getTime()
 
   //Save to local - do this last
   //Save to local
@@ -133,7 +135,7 @@ function addTodo(e) {
   infoButton.classList.add("edit-btn");
   todoDiv.appendChild(infoButton);
   infoButton.addEventListener("click", () => {
-    alert(`The todo item was created at ${createTime}, ${day}`)
+    alert(infoText)
   });
   //attach final Todo
   todoList.appendChild(todoDiv);
@@ -399,6 +401,16 @@ function getTodos() {
     trashButton.classList.add("trash-btn");
     todoDiv.setAttribute("key", todo.id);
     todoDiv.appendChild(trashButton);
+    //Create info button
+    if (!todo.infoText)
+      todo.infoText = "Create time not found.";
+    const infoButton = document.createElement("span");
+    infoButton.innerHTML = `<i class="fas fa-info-circle"></i>`;
+    infoButton.classList.add("edit-btn");
+    todoDiv.appendChild(infoButton);
+    infoButton.addEventListener("click", () => {
+      alert(todo.infoText)
+    });
     //attach final Todo
     todoList.appendChild(todoDiv);
   });


### PR DESCRIPTION
## Fix: #184 

## When page is refreshed info button disappears. Added fix for it.

## Screenshots:

- After refresh page Info button will be show for all Todo Item
![image](https://user-images.githubusercontent.com/30138146/194705930-519f999b-9b04-4dde-8705-015ea3513e0d.png)

- When Info not found for Todo item then message "Create time not found." will be display
![image](https://user-images.githubusercontent.com/30138146/194705961-47d00069-e44f-4d7c-ac71-ab63f215aa66.png)

- After page refresh when info is available then show info message.
![image](https://user-images.githubusercontent.com/30138146/194706021-66270fb5-7319-4c57-832a-62ab7ee3b05b.png)

Kindly check and let me know for any changes if required.

Thanks