### PR TITLE
Bug Fix - Fixed Horizontal scrollbar issue in the layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -563,7 +563,7 @@ select {
   body{
     background-color: rgb(247, 247, 249);
     min-height: 100vh;
-    width: 100vw;
+    width: 100%;  /* keeping width: 100 viewport width can cause horizontal scrollbar which is an issue */
     display: grid;
 }
 .Clock{

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -563,7 +563,7 @@ select {
   body{
     background-color: rgb(247, 247, 249);
     min-height: 100vh;
-    width: 100%;  /* keeping width: 100 viewport width can cause horizontal scrollbar which is an issue */
+    width: 100%;  /* keeping width: 100 viewport width can cause horizontal scrollbar which is an issue, fixed using percentage */
     display: grid;
 }
 .Clock{


### PR DESCRIPTION
Hi Avinash,

The width:100vw given to the body causes problems in the layout, I fixed it using percentage method. See the first screenshot it has a gap  in right side. Second Screenshot is the resolved screenshot.

Adding screenshot before & after the layout fixes.

Kindly approve my PR for the fix.

Adding Reference for the bug : [https://stackoverflow.com/questions/25225682/difference-between-width100-and-width100vw](url)

I just noticed that setting an element to be 100vw can cause a horizontal scrollbar to appear when a vertical scrollbar is visible. According to [Can I use](http://caniuse.com/#feat=viewport-units), only Firefox exhibits correct behavior by subtracting the scrollbar width from 100vw. For every other browser, you will need to use 100% instead.
![Screenshot (888)](https://user-images.githubusercontent.com/74542543/196127305-0291f6c9-e4ea-480c-b35c-531db65e4b84.png)
![Screenshot (889)](https://user-images.githubusercontent.com/74542543/196127372-6605e1a7-760b-4a92-a0c5-4c375c58f3f4.png)
