### PR TITLE
Change color of in-range-custom days in calendar

### DIFF
--- a/home.html
+++ b/home.html
@@ -304,7 +304,7 @@
     /* subtle range shading (in addition to the built-in selected styles) */
     .flatpickr-day.in-range-custom { 
       background: rgba(13,110,253,0.12) !important; 
-      color: inherit !important; 
+      color: #a671e3 !important; 
     }
 
     /* Notice text */


### PR DESCRIPTION
This PR resolves a readability issue within the "Visual Timeline" calendar.

### Problem

Dates falling within a task's duration (between the purple Start Date and green Due Date) use the light-colored custom shading (`in-range-custom`). Because the default text color in this area was also light, the date numbers were nearly invisible against the background.

### Solution

I have updated the CSS rule for `.flatpickr-day.in-range-custom` to explicitly set the text color to '#a671e3' from light grey .
<img width="400" height="600" alt="image" src="https://github.com/user-attachments/assets/626c8059-b872-4f2f-b68d-f3da69550170" />
**Modified CSS:**
```css
.flatpickr-day.in-range-custom { 
  background: rgba(13,110,253,0.12) !important;
  color: #a671e3 !important; /* Changed from 'inherit' to a dark color for readability */
}
Impact
Date numbers in the highlighted task range are now clearly legible, improving the user experience of the visual timeline.



